### PR TITLE
Safari can't read an outside const from a module script tag 

### DIFF
--- a/cli/html.ts
+++ b/cli/html.ts
@@ -25,7 +25,7 @@ export default function html(data: {
 <meta property="og:description" content="${data.title} - built with npmnotes" />
 
 <style>${data.css}</style>
-<script>const data = ${JSON.stringify(data.notes)}</script>
+<script>var data = ${JSON.stringify(data.notes)}</script>
 </head>
 
 <body>


### PR DESCRIPTION
In Safari, consts defined outside of the module tag are not accessible. I've checked Chrome, Firefox, Edge and Safari and only safari has this behaviour. 

Example:

```
<html>
  <head>
    <title> XXXXX </title>

  <script> 
      var x = "AA";
      const y = "BB";
    </script>
  </head>

  <body>

  <script>  
      console.log(x); // Works everywhere
      console.log(y); // Works everywhere
  </script>

  <script type="module">  
      console.log(x); // Works everywhere
      console.log(y); // Doesn't work in Safari
  </script>
  </body>


</html>

```